### PR TITLE
Remove duplicate usage print

### DIFF
--- a/ConsoleTemplate/template/Program.fs
+++ b/ConsoleTemplate/template/Program.fs
@@ -9,9 +9,7 @@ module console1 =
     let main argv = 
         printfn "%A" argv
 
-        let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
+        let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name))
         let results = parser.Parse argv
         Library.printParams (results.GetAllResults())
         printfn "Hit any key to exit."

--- a/src/PSMBasedQuantification/Program.fs
+++ b/src/PSMBasedQuantification/Program.fs
@@ -13,8 +13,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i = results.GetResult InstrumentOutput
         let ii = results.GetResult ScoredPSMs

--- a/src/PSMStatistics/Program.fs
+++ b/src/PSMStatistics/Program.fs
@@ -13,8 +13,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i = results.GetResult PSMs
         let o = results.GetResult OutputDirectory

--- a/src/PSMStatisticsXtandem/Program.fs
+++ b/src/PSMStatisticsXtandem/Program.fs
@@ -13,8 +13,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i = results.GetResult PSMs
         let o = results.GetResult OutputDirectory

--- a/src/PeptideDB/Program.fs
+++ b/src/PeptideDB/Program.fs
@@ -11,8 +11,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let outputDir = results.TryGetResult OutputDirectory
         let paramF = results.TryGetResult ParamFile

--- a/src/PeptideSpectrumMatching/Program.fs
+++ b/src/PeptideSpectrumMatching/Program.fs
@@ -12,8 +12,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i = results.GetResult InstrumentOutput
         let o = results.GetResult OutputDirectory

--- a/src/Preprocessing/Program.fs
+++ b/src/Preprocessing/Program.fs
@@ -11,8 +11,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i = results.GetResult InstrumentOutput
         let o = results.GetResult OutputDirectory

--- a/src/ProteinInference/Program.fs
+++ b/src/ProteinInference/Program.fs
@@ -10,8 +10,6 @@ module console1 =
         printfn "%A" argv
 
         let parser = ArgumentParser.Create<CLIArguments>(programName =  (System.Reflection.Assembly.GetExecutingAssembly().GetName().Name)) 
-        let usage  = parser.PrintUsage()
-        printfn "%s" usage
         let results = parser.Parse argv
         let i     = results.GetResult InputFolder
         let fastA = results.GetResult FastA


### PR DESCRIPTION
Remove prints that gave out a duplicate of the usage description. Also remove it from the project template.